### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Travis CI Status](https://travis-ci.org/jfischoff/tmp-postgres.svg?branch=master)](http://travis-ci.org/jfischoff/tmp-postgres)
 # tmp-postgres
 
-`tmp-postgres` is a libary for greating a temporary `postgres` instance on a random port for testing.
+`tmp-postgres` is a library for creating a temporary `postgres` instance on a random port for testing.
 
 ```haskell
 result <- start []

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ case result of
      stop tempDB
 ```
 
-#Installation
+# Installation
 
 ## macOS
 ```

--- a/tmp-postgres.cabal
+++ b/tmp-postgres.cabal
@@ -2,7 +2,7 @@ name:                tmp-postgres
 version:             0.1.0.7
 synopsis: Start and stop a temporary postgres for testing
 description:
- This module provides functions greating a temporary postgres instance on a random port for testing.
+ This module provides functions creating a temporary postgres instance on a random port for testing.
  .
  > result <- start []
  > case result of
@@ -15,7 +15,7 @@ description:
  methods of dealing with @stdout@ and @stderr@.
  .
  The start methods use a config based on the one used by pg_tmp (http://ephemeralpg.org/), but can be overriden
- by in different values to the first argument of the start functions.
+ by different values to the first argument of the start functions.
  .
  WARNING!!
  Ubuntu's PostgreSQL installation does not put @initdb@ on the @PATH@. We need to add it manually. The necessary binaries are in the @\/usr\/lib\/postgresql\/VERSION\/bin\/@ directory, and should be added to the @PATH@


### PR DESCRIPTION
Hi, hope I don't bother—noticed these typos when reading the library description, got a link to it (https://hackage.haskell.org/package/tmp-postgres).
Sorry for the many commits, you'll need a squash merge.