### PR TITLE
Use `ConnectInfo` instead of connection string in `DB`

### DIFF
--- a/src/Database/Postgres/Temp.hs
+++ b/src/Database/Postgres/Temp.hs
@@ -36,6 +36,7 @@ module Database.Postgres.Temp
   , startLocalhost
   , startAndLogToTmp
   , startWithHandles
+  , startWithHandlesAndDir
   -- * Stopping @postgres@
   , stop
   , SocketClass (..)

--- a/src/Database/Postgres/Temp.hs
+++ b/src/Database/Postgres/Temp.hs
@@ -39,6 +39,8 @@ module Database.Postgres.Temp
   -- * Stopping @postgres@
   , stop
   , SocketClass (..)
+  -- * Helpers
+  , mkConnectionString
   ) where
 import Database.Postgres.Temp.Internal
 

--- a/test/Database/Postgres/Temp/InternalSpec.hs
+++ b/test/Database/Postgres/Temp/InternalSpec.hs
@@ -10,7 +10,6 @@ import System.Directory
 import Control.Monad
 import System.Process
 import Database.PostgreSQL.Simple
-import qualified Data.ByteString.Char8 as BSC
 import System.Exit
 import Control.Applicative ((<$>))
 
@@ -49,7 +48,7 @@ spec = describe "Database.Postgres.Temp.Internal" $ do
       db <- case result of
               Right x  -> return x
               Left err -> error $ show err
-      conn <- connectPostgreSQL $ BSC.pack $ connectionString db
+      conn <- connect $ connectionInfo db
       _ <- execute_ conn "create table users (id int)"
 
       stop db `shouldReturn` ExitSuccess
@@ -63,6 +62,6 @@ spec = describe "Database.Postgres.Temp.Internal" $ do
         db <- case result of
                 Right x  -> return x
                 Left err -> error $ show err
-        conn <- connectPostgreSQL $ BSC.pack $ connectionString db
+        conn <- connect $ connectionInfo db
         [Only actualDuration] <- query_ conn "SHOW log_min_duration_statement"
         actualDuration `shouldBe` expectedDuration

--- a/tmp-postgres.cabal
+++ b/tmp-postgres.cabal
@@ -1,5 +1,5 @@
 name:                tmp-postgres
-version:             0.1.1.1
+version:             0.2.0.0
 synopsis: Start and stop a temporary postgres for testing
 description:
  This module provides functions creating a temporary postgres instance on a random port for testing.


### PR DESCRIPTION
**Please note**: This bumps the version to `0.2`, as this is a change to the public API.

While using `tmp-postgres` to test an application, I found it really useful to have a `ConnectInfo` value rather than a connection string. In general I think it's a good idea to use richer types by default, and allow conversions where necessary. As a result, I think `ConnectInfo` should be in `DB`, and a helper function exported for conversion to a connection string.