### PR TITLE
Add restarting and config reloading support

### DIFF
--- a/src/Database/Postgres/Temp.hs
+++ b/src/Database/Postgres/Temp.hs
@@ -38,6 +38,11 @@ module Database.Postgres.Temp
   , startWithHandles
   -- * Stopping @postgres@
   , stop
+  -- * Starting and Stopping postgres without removing the temporary directory
+  , startPostgres
+  , stopPostgres
+  -- * Reloading the config
+  , reloadConfig
   , SocketClass (..)
   ) where
 import Database.Postgres.Temp.Internal

--- a/src/Database/Postgres/Temp/Internal.hs
+++ b/src/Database/Postgres/Temp/Internal.hs
@@ -19,6 +19,7 @@ import Control.Monad (void, forever)
 import Network.Socket.Free (openFreePort)
 import Data.Foldable
 import Control.Concurrent.Async(race_)
+import Data.IORef
 
 getFreePort :: IO Int
 getFreePort = do
@@ -33,13 +34,28 @@ waitForDB connStr = do
     Left (_ :: IOError) -> threadDelay 10000 >> waitForDB connStr
     Right _ -> return ()
 
+-- A helper for dealing with locks
+withLock :: MVar a -> IO b -> IO b
+withLock m f = withMVar m (const f)
 
 data DB = DB
-  { mainDir          :: FilePath
+  { mainDir :: FilePath
   -- ^ Temporary directory where the unix socket, logs and data directory live.
   , connectionString :: String
   -- ^ PostgreSQL connection string.
-  , pid              :: ProcessHandle
+  , extraOptions :: [(String, String)]
+  -- ^ Additionally options passed to the postgres command line
+  , stdErr :: Handle
+  -- ^ The 'Handle' used to standard error
+  , stdOut :: Handle
+  -- ^ The 'Handle' used to standard output
+  , pidLock :: MVar ()
+  -- ^ A lock used internally to makes sure access to 'pid' is serialized
+  , port :: Int
+  -- ^ The port postgres is listening on
+  , socketClass :: SocketClass
+  -- ^ The 'SocketClass' used for starting postgres
+  , pid :: IORef (Maybe ProcessHandle)
   -- ^ The process handle for the @postgres@ process.
   }
 
@@ -85,6 +101,7 @@ data StartError
   = InitDBFailed   ExitCode
   | CreateDBFailed [String] ExitCode
   | StartPostgresFailed [String] ExitCode
+  | StartPostgresDisappeared [String]
   deriving (Show, Eq, Typeable)
 
 instance Exception StartError
@@ -127,6 +144,98 @@ startWithHandlesAndDir :: SocketClass
                        -> IO (Either StartError DB)
 startWithHandlesAndDir = startWithLogger $ \_ -> return ()
 
+-- | This error is thrown is 'startPostgres' is called twice without calling
+--  'stopPostgres' first.
+data AnotherPostgresProcessActive = AnotherPostgresProcessActive
+  deriving (Show, Eq, Typeable)
+
+instance Exception AnotherPostgresProcessActive
+
+-- A helper that attempts to blocks until a connection can be made, throws
+-- 'StartPostgresFailed' if the postgres process fails or throws
+-- 'StartPostgresDisappeared' if the 'pid' somehow becomes 'Nothinng'.
+waitOnPostgres :: DB -> IO ()
+waitOnPostgres DB {..} = do
+  let postgresOptions = makePostgresOptions extraOptions (mainDir ++ "/data") port
+      checkForCrash = readIORef pid >>= \case
+        Nothing -> throwIO $ StartPostgresDisappeared postgresOptions
+        Just thePid -> do
+          mExitCode <- getProcessExitCode thePid
+          for_ mExitCode (throwIO . StartPostgresFailed postgresOptions)
+      host = case socketClass of
+            Localhost -> "127.0.0.1"
+            Unix -> mainDir
+      makeConnectionString dbName = "postgresql:///"
+          ++ dbName ++ "?host=" ++ host ++ "&port=" ++ show port
+
+  waitForDB (makeConnectionString "template1") `race_`
+    forever (checkForCrash >> threadDelay 100000)
+
+-- | Send the SIGHUP signal to the postgres process to start a config reload
+reloadConfig :: DB -> IO ()
+reloadConfig DB {..} = do
+  mHandle <- readIORef pid
+  for_ mHandle $ \theHandle -> do
+    mPid <- getPid theHandle
+    for_ mPid $ signalProcess sigHUP
+
+-- | This throws 'AnotherPostgresProcessActive' if the postgres
+--  has not been stopped using 'stopPostgres'.
+--  This function attempts to the 'pidLock' before running.
+--  If postgres process fails this throws 'StartPostgresFailed'.
+--  If the postgres process becomes 'Nothing' while starting
+--  this function throws 'StartPostgresDisappeared'.
+startPostgres :: DB -> IO ()
+startPostgres db@DB {..} = withLock pidLock $ do
+  readIORef pid >>= \case
+    Just _ -> throwIO AnotherPostgresProcessActive
+    Nothing -> do
+      let postgresOptions = makePostgresOptions extraOptions (mainDir ++ "/data") port
+      bracketOnError
+        (runPostgres stdErr stdOut postgresOptions)
+        (const $ stopPostgres db)
+        $ \thePid -> do
+          writeIORef pid $ Just thePid
+          waitOnPostgres db
+
+-- | Stop the postgres process. This function attempts to the 'pidLock' before running.
+--   'stopPostgres' will terminate all connections before shutting down postgres.
+--   'stopPostgres' is useful for testing backup strategies.
+stopPostgres :: DB -> IO (Maybe ExitCode)
+stopPostgres db@DB {..} = withLock pidLock $ readIORef pid >>= \case
+  Nothing -> pure Nothing
+  Just pHandle -> do
+    withProcessHandle pHandle (\case
+          OpenHandle p   -> do
+            -- try to terminate the connects first. If we can't terminate still
+            -- keep shutting down
+            terminateConnections db
+
+            signalProcess sigINT p
+          OpenExtHandle _ _ _ -> pure () -- TODO log windows is not supported
+          ClosedHandle _ -> return ()
+          )
+
+    exitCode <- waitForProcess pHandle
+    writeIORef pid Nothing
+    pure $ Just exitCode
+
+makePostgresOptions :: [(String, String)]
+                    -> FilePath
+                    -> Int
+                    -> [String]
+makePostgresOptions options dataDir port =
+  let extraOptions = map (\(key, value) -> "--" ++ key ++ "=" ++ value) options
+  in ["-D", dataDir, "-p", show port] ++ extraOptions
+
+runPostgres :: Handle
+            -> Handle
+            -> [String]
+            -> IO ProcessHandle
+runPostgres theStdOut theStdErr postgresOptions = do
+  fmap fourth $ createProcess_ "postgres" $
+    procWith theStdOut theStdErr "postgres" postgresOptions
+
 data Event
   = InitDB
   | WriteConfig
@@ -148,7 +257,7 @@ startWithLogger :: (Event -> IO ())
                 -> Handle
                 -> Handle
                 -> IO (Either StartError DB)
-startWithLogger logger socketType options mainDir stdOut stdErr = try $ flip onException (rmDirIgnoreErrors mainDir) $ do
+startWithLogger logger socketClass options mainDir stdOut stdErr = try $ flip onException (rmDirIgnoreErrors mainDir) $ do
   let dataDir = mainDir ++ "/data"
 
   logger InitDB
@@ -157,37 +266,39 @@ startWithLogger logger socketType options mainDir stdOut stdErr = try $ flip onE
   throwIfError InitDBFailed initDBExitCode
 
   logger WriteConfig
-  writeFile (dataDir ++ "/postgresql.conf") $ config $ if socketType == Unix then Just mainDir else Nothing
+  writeFile (dataDir ++ "/postgresql.conf") $ config $ if socketClass == Unix then Just mainDir else Nothing
 
   logger FreePort
   port <- getFreePort
   -- slight race here, the port might not be free anymore!
-  let host = case socketType of
+  let host = case socketClass of
         Localhost -> "127.0.0.1"
         Unix -> mainDir
   let makeConnectionString dbName = "postgresql:///"
         ++ dbName ++ "?host=" ++ host ++ "&port=" ++ show port
       connectionString = makeConnectionString "test"
   logger StartPostgres
-  let extraOptions = map (\(key, value) -> "--" ++ key ++ "=" ++ value) options
-      postgresOptions = ["-D", dataDir, "-p", show port] ++ extraOptions
-  bracketOnError ( fmap (DB mainDir connectionString . fourth)
-                 $ createProcess_ "postgres"
-                     (procWith stdOut stdErr "postgres" postgresOptions)
-                 )
-                 stop
-                 $ \result -> do
+  pidLock <- newMVar ()
 
-    let checkForCrash =
-          getProcessExitCode (pid result) >>=
-            traverse_ (throwIO . StartPostgresFailed postgresOptions)
+  let postgresOptions = makePostgresOptions options dataDir port
+      createDBResult = do
+        thePid <- runPostgres stdOut stdErr postgresOptions
+        pid <- newIORef $ Just thePid
+        pure $ DB mainDir connectionString options stdErr stdOut pidLock port socketClass pid
+
+  bracketOnError createDBResult stop $ \result -> do
+    let checkForCrash = readIORef (pid result) >>= \case
+          Nothing -> throwIO $ StartPostgresDisappeared postgresOptions
+          Just thePid -> do
+            mExitCode <- getProcessExitCode thePid
+            for_ mExitCode (throwIO . StartPostgresFailed postgresOptions)
 
     logger WaitForDB
     waitForDB (makeConnectionString "template1") `race_`
       forever (checkForCrash >> threadDelay 100000)
 
     logger CreateDB
-    let createDBHostArgs = case socketType of
+    let createDBHostArgs = case socketClass of
           Unix -> ["-h", mainDir]
           Localhost -> ["-h", "127.0.0.1"]
 
@@ -223,20 +334,8 @@ terminateConnections DB {..} = do
     Right _ -> pure () -- Surprising ... but I do not know yet if this is a failure of termination or not.
 
 -- | Stop postgres and clean up the temporary database folder.
-stop :: DB -> IO ExitCode
+stop :: DB -> IO (Maybe ExitCode)
 stop db@DB {..} = do
-
-  withProcessHandle pid (\case
-         OpenHandle p   -> do
-          -- try to terminate the connects first. If we can't terminate still
-          -- keep shutting down
-          terminateConnections db
-
-          signalProcess sigINT p
-         OpenExtHandle _ _ _ -> pure () -- TODO log windows is not supported
-         ClosedHandle _ -> return ()
-         )
-
-  result <- waitForProcess pid
+  result <- stopPostgres db
   removeDirectoryRecursive mainDir
   return result

--- a/tmp-postgres.cabal
+++ b/tmp-postgres.cabal
@@ -1,5 +1,5 @@
 name:                tmp-postgres
-version:             0.1.2.2
+version:             0.2.0.0
 synopsis: Start and stop a temporary postgres for testing
 description:
  This module provides functions creating a temporary postgres instance on a random port for testing.
@@ -31,7 +31,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Jonathan Fischoff
 maintainer:          jonathangfischoff@gmail.com
-copyright:           2017 Jonathan Fischoff
+copyright:           2017-2019 Jonathan Fischoff
 category:            Web
 build-type:          Simple
 extra-source-files:  README.md


### PR DESCRIPTION
The main reason for adding the ability to start and stop the postgres process is to enable testing of backup strategies. It makes everything else more complicated and is forces a backward incompatible major version bump.