### PR TITLE
Migrate to `prettyprinter` from deprecated `ansi-wl-pprint`

### DIFF
--- a/src/Database/Postgres/Temp/Internal.hs
+++ b/src/Database/Postgres/Temp/Internal.hs
@@ -19,10 +19,10 @@ import           Data.ByteString (ByteString)
 import qualified Data.Map.Strict as Map
 import qualified Database.PostgreSQL.Simple.Options as Client
 import           GHC.Generics
+import           Prettyprinter
 import           System.Exit (ExitCode(..))
 import           System.IO.Unsafe (unsafePerformIO)
 import           System.Process
-import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 import           System.Directory
 
 -- | Handle for holding temporary resources, the @postgres@ process handle
@@ -40,11 +40,11 @@ data DB = DB
 
 instance Pretty DB where
   pretty DB {..}
-    =  text "dbResources"
+    =  "dbResources"
     <> softline
     <> indent 2 (pretty dbResources)
     <> hardline
-    <> text "dbPostgresProcess"
+    <> "dbPostgresProcess"
     <> softline
     <> indent 2 (pretty dbPostgresProcess)
 

--- a/tmp-postgres.cabal
+++ b/tmp-postgres.cabal
@@ -40,7 +40,6 @@ library
     , ViewPatterns
   build-depends: base >= 4.6 && < 5
                , base64-bytestring
-               , ansi-wl-pprint
                , async
                , bytestring
                , containers
@@ -51,6 +50,7 @@ library
                , port-utils
                , postgres-options >= 0.2.0.0
                , postgresql-simple
+               , prettyprinter
                , process >= 1.2.0.0
                , stm
                , temporary


### PR DESCRIPTION
We replace the `text` function in most places in favour of just using the already-enabled `OverloadedStrings`, or with `pretty` when not using string literals.

Where the old instance `Pretty a => Pretty (Maybe a)` was relied upon, we replace `pretty` with `maybe mempty id` (then apply an HLint-suggested simplification), which is what we'd get from inlining a few definitions with the old library.