### PR TITLE
Shorten temporary directory paths

### DIFF
--- a/src/Database/Postgres/Temp/Internal/Config.hs
+++ b/src/Database/Postgres/Temp/Internal/Config.hs
@@ -799,9 +799,9 @@ setupConfig config@Config {..} = evalContT $ do
       resourcesTemporaryDir = fromMaybe defaultTemp $ getLast temporaryDirectory
       resourcesInitDbCache = join $ getLast initDbCache
   resourcesSocketDirectory <- ContT $ bracketOnError
-    (setupDirectoryType resourcesTemporaryDir "tmp-postgres-socket" socketDirectory) cleanupDirectoryType
+    (setupDirectoryType resourcesTemporaryDir "socket" socketDirectory) cleanupDirectoryType
   resourcesDataDir <- ContT $ bracketOnError
-    (setupDirectoryType resourcesTemporaryDir "tmp-postgres-data" dataDirectory) cleanupDirectoryType
+    (setupDirectoryType resourcesTemporaryDir "data" dataDirectory) cleanupDirectoryType
   let hostAndDir = toPlan
         (hasInitDb config)
         (hasCreateDb config)


### PR DESCRIPTION
Shortens temporary directory paths by ~13 bytes, to prevent errors when constructing Unix-domain socket paths:

    LOG:  Unix-domain socket path "/private/tmp/nix-build-aaaaaaa-aaaaaaaaaa-0.1.0.0.drv-0/tmp-postgres-socket-88e650c49cd6880b/.s.PGSQL.63901" is too long (maximum 103 bytes)
    WARNING:  could not create Unix-domain socket in directory "/private/tmp/nix-build-aaaaaaa-aaaaaaaaaa-0.1.0.0.drv-0/tmp-postgres-socket-88e650c49cd6880b"
    FATAL:  could not create any Unix-domain sockets